### PR TITLE
Fixed spelling error for `mkdir` in DENSE_TABLE_RETRIEVER.md

### DIFF
--- a/DENSE_TABLE_RETRIEVER.md
+++ b/DENSE_TABLE_RETRIEVER.md
@@ -58,7 +58,7 @@ gsutil -m cp -R "gs://${GCP_BUCKET}/nq_tables/*" "${nq_data_dir}"
 Or you can also run the pipeline locally but that will take a long time and memory:
 
 ```bash
-mdkir -p "${nq_data_dir}/raw"
+mkdir -p "${nq_data_dir}/raw"
 gsutil -m cp -R gs://natural_questions/v1.0/* "${nq_data_dir}/raw"
 python3 tapas/scripts/preprocess_nq.py \
   --input_path="gs://natural_questions/v1.0" \


### PR DESCRIPTION
Minor change for the example code to fix the spelling error for `mkdir`