### PR TITLE
fix: disable v2 behaviour classifier experiment

### DIFF
--- a/tapas/experiments/tapas_classifier_experiment.py
+++ b/tapas/experiments/tapas_classifier_experiment.py
@@ -31,6 +31,9 @@ from tapas.utils import attention_utils
 from tapas.utils import experiment_utils  # pylint: disable=unused-import
 import tensorflow.compat.v1 as tf
 from tensorflow.compat.v1 import estimator as tf_estimator
+
+tf.disable_v2_behavior()
+
 FLAGS = flags.FLAGS
 
 flags.DEFINE_string("data_format", "tfrecord", "The input data format.")


### PR DESCRIPTION
* Tapas classifier file doesn't disable v2 tf behaviour, which leads to error during running the experiment:

```
hidden_size_agg = output_layer_aggregation.shape[-1].value
AttributeError: 'int' object has no attribute 'value'
```

Resolve issue:
https://github.com/google-research/tapas/issues/187